### PR TITLE
[AIRFLOW-3231] Basic operators for Google Cloud SQL

### DIFF
--- a/airflow/contrib/example_dags/example_gcp_sql.py
+++ b/airflow/contrib/example_dags/example_gcp_sql.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+Example Airflow DAG that deploys, updates, patches and deletes a Cloud SQL instance
+in Google Cloud Platform.
+
+This DAG relies on the following Airflow variables
+https://airflow.apache.org/concepts.html#variables
+* PROJECT_ID - Google Cloud Platform project for the Cloud SQL instance.
+* INSTANCE_NAME - Name of the Cloud SQL instance.
+"""
+
+import datetime
+
+import airflow
+from airflow import models
+
+from airflow.contrib.operators.gcp_sql_operator import CloudSqlInstanceInsertOperator, \
+    CloudSqlInstancePatchOperator, CloudSqlInstanceDeleteOperator
+
+# [START howto_operator_cloudsql_arguments]
+PROJECT_ID = models.Variable.get('PROJECT_ID', '')
+INSTANCE_NAME = models.Variable.get('INSTANCE_NAME', '')
+# [END howto_operator_cloudsql_arguments]
+
+# Bodies below represent Cloud SQL instance resources:
+# https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/instances
+
+# [START howto_operator_cloudsql_insert_body]
+body = {
+    "name": INSTANCE_NAME,
+    "settings": {
+        "tier": "db-n1-standard-1",
+        "backupConfiguration": {
+            "binaryLogEnabled": True,
+            "enabled": True,
+            "startTime": "05:00"
+        },
+        "activationPolicy": "ALWAYS",
+        "dataDiskSizeGb": 30,
+        "dataDiskType": "PD_SSD",
+        "databaseFlags": [],
+        "ipConfiguration": {
+            "ipv4Enabled": True,
+            "requireSsl": True,
+        },
+        "locationPreference": {
+            "zone": "europe-west4-a"
+        },
+        "maintenanceWindow": {
+            "hour": 5,
+            "day": 7,
+            "updateTrack": "canary"
+        },
+        "pricingPlan": "PER_USE",
+        "replicationType": "ASYNCHRONOUS",
+        "storageAutoResize": False,
+        "storageAutoResizeLimit": 0,
+        "userLabels": {
+            "my-key": "my-value"
+        }
+    },
+    "databaseVersion": "MYSQL_5_7",
+    "region": "europe-west4",
+}
+# [END howto_operator_cloudsql_insert_body]
+# [START howto_operator_cloudsql_patch_body]
+patch_body = {
+    "name": INSTANCE_NAME,
+    "settings": {
+        "dataDiskSizeGb": 35,
+        "maintenanceWindow": {
+            "hour": 3,
+            "day": 6,
+            "updateTrack": "canary"
+        },
+        "userLabels": {
+            "my-key-patch": "my-value-patch"
+        }
+    }
+}
+# [END howto_operator_cloudsql_patch_body]
+
+default_args = {
+    'start_date': airflow.utils.dates.days_ago(1)
+}
+
+with models.DAG(
+    'example_gcp_sql',
+    default_args=default_args,
+    schedule_interval=datetime.timedelta(days=1)
+) as dag:
+    # [START howto_operator_cloudsql_insert]
+    sql_instance_insert_task = CloudSqlInstanceInsertOperator(
+        project_id=PROJECT_ID,
+        body=body,
+        name=INSTANCE_NAME,
+        task_id='sql_instance_insert_task'
+    )
+    # [END howto_operator_cloudsql_insert]
+    # [START howto_operator_cloudsql_patch]
+    sql_instance_patch_task = CloudSqlInstancePatchOperator(
+        project_id=PROJECT_ID,
+        body=patch_body,
+        name=INSTANCE_NAME,
+        task_id='sql_instance_patch_task'
+    )
+    # [END howto_operator_cloudsql_patch]
+    # [START howto_operator_cloudsql_delete]
+    sql_instance_delete_task = CloudSqlInstanceDeleteOperator(
+        project_id=PROJECT_ID,
+        name=INSTANCE_NAME,
+        task_id='sql_instance_delete_task'
+    )
+    # [END howto_operator_cloudsql_delete]
+
+    sql_instance_insert_task >> sql_instance_patch_task >> sql_instance_delete_task

--- a/airflow/contrib/example_dags/example_gcp_sql.py
+++ b/airflow/contrib/example_dags/example_gcp_sql.py
@@ -111,7 +111,7 @@ with models.DAG(
     sql_instance_insert_task = CloudSqlInstanceInsertOperator(
         project_id=PROJECT_ID,
         body=body,
-        name=INSTANCE_NAME,
+        instance=INSTANCE_NAME,
         task_id='sql_instance_insert_task'
     )
     # [END howto_operator_cloudsql_insert]
@@ -119,14 +119,14 @@ with models.DAG(
     sql_instance_patch_task = CloudSqlInstancePatchOperator(
         project_id=PROJECT_ID,
         body=patch_body,
-        name=INSTANCE_NAME,
+        instance=INSTANCE_NAME,
         task_id='sql_instance_patch_task'
     )
     # [END howto_operator_cloudsql_patch]
     # [START howto_operator_cloudsql_delete]
     sql_instance_delete_task = CloudSqlInstanceDeleteOperator(
         project_id=PROJECT_ID,
-        name=INSTANCE_NAME,
+        instance=INSTANCE_NAME,
         task_id='sql_instance_delete_task'
     )
     # [END howto_operator_cloudsql_delete]

--- a/airflow/contrib/hooks/gcp_sql_hook.py
+++ b/airflow/contrib/hooks/gcp_sql_hook.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import time
+from googleapiclient.discovery import build
+
+from airflow import AirflowException
+from airflow.contrib.hooks.gcp_api_base_hook import GoogleCloudBaseHook
+
+# Number of retries - used by googleapiclient method calls to perform retries
+# For requests that are "retriable"
+NUM_RETRIES = 5
+
+# Time to sleep between active checks of the operation results
+TIME_TO_SLEEP_IN_SECONDS = 1
+
+
+class CloudSqlOperationStatus:
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    DONE = "DONE"
+    UNKNOWN = "UNKNOWN"
+
+
+# noinspection PyAbstractClass
+class CloudSqlHook(GoogleCloudBaseHook):
+    """
+    Hook for Google Cloud SQL APIs.
+    """
+    _conn = None
+
+    def __init__(self,
+                 api_version,
+                 gcp_conn_id='google_cloud_default',
+                 delegate_to=None):
+        super(CloudSqlHook, self).__init__(gcp_conn_id, delegate_to)
+        self.api_version = api_version
+
+    def get_conn(self):
+        """
+        Retrieves connection to Cloud SQL.
+
+        :return: Google Cloud SQL services object.
+        :rtype: dict
+        """
+        if not self._conn:
+            http_authorized = self._authorize()
+            self._conn = build('sqladmin', self.api_version,
+                               http=http_authorized, cache_discovery=False)
+        return self._conn
+
+    def get_instance(self, project_id, instance_id):
+        """
+        Retrieves a resource containing information about a Cloud SQL instance.
+
+        :param project_id: Project ID of the project that contains the instance.
+        :type project_id: str
+        :param instance_id: Database instance ID. This does not include the project ID.
+        :type instance_id: str
+        :return: A Cloud SQL instance resource.
+        :rtype: dict
+        """
+        return self.get_conn().instances().get(
+            project=project_id,
+            instance=instance_id
+        ).execute(num_retries=NUM_RETRIES)
+
+    def insert_instance(self, project_id, body):
+        """
+        Inserts a Cloud SQL instance defined by project_id and body.
+
+        :param project_id: Project ID of the project where the instance will be created.
+        :type project_id: str
+        :param body: Body required by the Cloud SQL insert API, as described in
+            https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/instances/insert#request-body
+        :type body: dict
+        :return: True if the operation succeeded, raises an error otherwise
+        :rtype: bool
+        """
+        response = self.get_conn().instances().insert(
+            project=project_id,
+            body=body
+        ).execute(num_retries=NUM_RETRIES)
+        operation_name = response["name"]
+        return self._wait_for_operation_to_complete(project_id, operation_name)
+
+    def patch_instance(self, project_id, body, instance_id):
+        """
+        Partially updates a Cloud SQL instance defined by project_id, body and
+        instance_id.
+
+        :param project_id: Project ID of the project where the instance exists.
+        :type project_id: str
+        :param body: Body required by the Cloud SQL patch API, as described in
+            https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/instances/patch#request-body
+        :type body: dict
+        :param instance_id: Name of the Cloud SQL instance. This does not include the
+            project ID.
+        :type instance_id: str
+        :return: True if the operation succeeded, raises an error otherwise
+        :rtype: bool
+        """
+        response = self.get_conn().instances().patch(
+            project=project_id,
+            instance=instance_id,
+            body=body
+        ).execute(num_retries=NUM_RETRIES)
+        operation_name = response["name"]
+        return self._wait_for_operation_to_complete(project_id, operation_name)
+
+    def delete_instance(self, project_id, instance_id):
+        """
+        Deletes a Cloud SQL instance defined by project_id and instance_id.
+
+        :param project_id: Project ID of the project where the instance exists.
+        :type project_id: str
+        :param instance_id: Name of the Cloud SQL instance. This does not include the
+            project ID.
+        :type instance_id: str
+        :return: True if the operation succeeded, raises an error otherwise
+        :rtype: bool
+        """
+        response = self.get_conn().instances().delete(
+            project=project_id,
+            instance=instance_id,
+        ).execute(num_retries=NUM_RETRIES)
+        operation_name = response["name"]
+        return self._wait_for_operation_to_complete(project_id, operation_name)
+
+    def _wait_for_operation_to_complete(self, project_id, operation_name):
+        """
+        Waits for the named operation to complete - checks status of the
+        asynchronous call.
+
+        :param operation_name: name of the operation
+        :type operation_name: str
+        :return: response returned by the operation
+        :rtype: dict
+        """
+        service = self.get_conn()
+        while True:
+            operation_response = service.operations().get(
+                project=project_id,
+                operation=operation_name,
+            ).execute(num_retries=NUM_RETRIES)
+            if operation_response.get("status") == CloudSqlOperationStatus.DONE:
+                error = operation_response.get("error")
+                if error:
+                    # Extracting the errors list as string and trimming square braces
+                    error_msg = str(error.get("errors"))[1:-1]
+                    raise AirflowException(error_msg)
+                # No meaningful info to return from the response in case of success
+                return True
+            time.sleep(TIME_TO_SLEEP_IN_SECONDS)

--- a/airflow/contrib/hooks/gcp_sql_hook.py
+++ b/airflow/contrib/hooks/gcp_sql_hook.py
@@ -65,27 +65,28 @@ class CloudSqlHook(GoogleCloudBaseHook):
                                http=http_authorized, cache_discovery=False)
         return self._conn
 
-    def get_instance(self, project_id, instance_id):
+    def get_instance(self, project_id, instance):
         """
         Retrieves a resource containing information about a Cloud SQL instance.
 
         :param project_id: Project ID of the project that contains the instance.
         :type project_id: str
-        :param instance_id: Database instance ID. This does not include the project ID.
-        :type instance_id: str
+        :param instance: Database instance ID. This does not include the project ID.
+        :type instance: str
         :return: A Cloud SQL instance resource.
         :rtype: dict
         """
         return self.get_conn().instances().get(
             project=project_id,
-            instance=instance_id
+            instance=instance
         ).execute(num_retries=NUM_RETRIES)
 
     def insert_instance(self, project_id, body):
         """
-        Inserts a Cloud SQL instance defined by project_id and body.
+        Creates a new Cloud SQL instance.
 
-        :param project_id: Project ID of the project where the instance will be created.
+        :param project_id: Project ID of the project to which the newly created
+            Cloud SQL instances should belong.
         :type project_id: str
         :param body: Body required by the Cloud SQL insert API, as described in
             https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/instances/insert#request-body
@@ -100,45 +101,45 @@ class CloudSqlHook(GoogleCloudBaseHook):
         operation_name = response["name"]
         return self._wait_for_operation_to_complete(project_id, operation_name)
 
-    def patch_instance(self, project_id, body, instance_id):
+    def patch_instance(self, project_id, body, instance):
         """
-        Partially updates a Cloud SQL instance defined by project_id, body and
-        instance_id.
+        Updates settings of a Cloud SQL instance.
 
-        :param project_id: Project ID of the project where the instance exists.
+        Caution: This is not a partial update, so you must include values for
+        all the settings that you want to retain.
+
+        :param project_id: Project ID of the project that contains the instance.
         :type project_id: str
         :param body: Body required by the Cloud SQL patch API, as described in
             https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/instances/patch#request-body
         :type body: dict
-        :param instance_id: Name of the Cloud SQL instance. This does not include the
-            project ID.
-        :type instance_id: str
+        :param instance: Cloud SQL instance ID. This does not include the project ID.
+        :type instance: str
         :return: True if the operation succeeded, raises an error otherwise
         :rtype: bool
         """
         response = self.get_conn().instances().patch(
             project=project_id,
-            instance=instance_id,
+            instance=instance,
             body=body
         ).execute(num_retries=NUM_RETRIES)
         operation_name = response["name"]
         return self._wait_for_operation_to_complete(project_id, operation_name)
 
-    def delete_instance(self, project_id, instance_id):
+    def delete_instance(self, project_id, instance):
         """
-        Deletes a Cloud SQL instance defined by project_id and instance_id.
+        Deletes a Cloud SQL instance.
 
-        :param project_id: Project ID of the project where the instance exists.
+        :param project_id: Project ID of the project that contains the instance.
         :type project_id: str
-        :param instance_id: Name of the Cloud SQL instance. This does not include the
-            project ID.
-        :type instance_id: str
+        :param instance: Cloud SQL instance ID. This does not include the project ID.
+        :type instance: str
         :return: True if the operation succeeded, raises an error otherwise
         :rtype: bool
         """
         response = self.get_conn().instances().delete(
             project=project_id,
-            instance=instance_id,
+            instance=instance,
         ).execute(num_retries=NUM_RETRIES)
         operation_name = response["name"]
         return self._wait_for_operation_to_complete(project_id, operation_name)
@@ -148,6 +149,8 @@ class CloudSqlHook(GoogleCloudBaseHook):
         Waits for the named operation to complete - checks status of the
         asynchronous call.
 
+        :param project_id: Project ID of the project that contains the instance.
+        :type project_id: str
         :param operation_name: name of the operation
         :type operation_name: str
         :return: response returned by the operation

--- a/airflow/contrib/operators/gcp_sql_operator.py
+++ b/airflow/contrib/operators/gcp_sql_operator.py
@@ -1,0 +1,288 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from googleapiclient.errors import HttpError
+
+from airflow import AirflowException
+from airflow.contrib.hooks.gcp_sql_hook import CloudSqlHook
+from airflow.contrib.utils.gcp_field_validator import GcpBodyFieldValidator
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+SETTINGS = 'settings'
+SETTINGS_VERSION = 'settingsVersion'
+
+CLOUD_SQL_VALIDATION = [
+    dict(name="name", allow_empty=False),
+    dict(name="settings", type="dict", fields=[
+        dict(name="tier", allow_empty=False),
+        dict(name="backupConfiguration", type="dict", fields=[
+            dict(name="binaryLogEnabled", optional=True),
+            dict(name="enabled", optional=True),
+            dict(name="replicationLogArchivingEnabled", optional=True),
+            dict(name="startTime", allow_empty=False, optional=True)
+        ], optional=True),
+        dict(name="activationPolicy", allow_empty=False, optional=True),
+        dict(name="authorizedGaeApplications", type="list", optional=True),
+        dict(name="crashSafeReplicationEnabled", optional=True),
+        dict(name="dataDiskSizeGb", optional=True),
+        dict(name="dataDiskType", allow_empty=False, optional=True),
+        dict(name="databaseFlags", type="list", optional=True),
+        dict(name="ipConfiguration", type="dict", fields=[
+            dict(name="authorizedNetworks", type="list", fields=[
+                dict(name="expirationTime", optional=True),
+                dict(name="name", allow_empty=False, optional=True),
+                dict(name="value", allow_empty=False, optional=True)
+            ], optional=True),
+            dict(name="ipv4Enabled", optional=True),
+            dict(name="privateNetwork", allow_empty=False, optional=True),
+            dict(name="requireSsl", optional=True),
+        ], optional=True),
+        dict(name="locationPreference", type="dict", fields=[
+            dict(name="followGaeApplication", allow_empty=False, optional=True),
+            dict(name="zone", allow_empty=False, optional=True),
+        ], optional=True),
+        dict(name="maintenanceWindow", type="dict", fields=[
+            dict(name="hour", optional=True),
+            dict(name="day", optional=True),
+            dict(name="updateTrack", allow_empty=False, optional=True),
+        ], optional=True),
+        dict(name="pricingPlan", allow_empty=False, optional=True),
+        dict(name="replicationType", allow_empty=False, optional=True),
+        dict(name="storageAutoResize", optional=True),
+        dict(name="storageAutoResizeLimit", optional=True),
+        dict(name="userLabels", type="dict", optional=True),
+    ]),
+    dict(name="databaseVersion", allow_empty=False, optional=True),
+    dict(name="failoverReplica", type="dict", fields=[
+        dict(name="name", allow_empty=False)
+    ], optional=True),
+    dict(name="masterInstanceName", allow_empty=False, optional=True),
+    dict(name="onPremisesConfiguration", type="dict", optional=True),
+    dict(name="region", allow_empty=False, optional=True),
+    dict(name="replicaConfiguration", type="dict", fields=[
+        dict(name="failoverTarget", optional=True),
+        dict(name="mysqlReplicaConfiguration", type="dict", fields=[
+            dict(name="caCertificate", allow_empty=False, optional=True),
+            dict(name="clientCertificate", allow_empty=False, optional=True),
+            dict(name="clientKey", allow_empty=False, optional=True),
+            dict(name="connectRetryInterval", optional=True),
+            dict(name="dumpFilePath", allow_empty=False, optional=True),
+            dict(name="masterHeartbeatPeriod", optional=True),
+            dict(name="password", allow_empty=False, optional=True),
+            dict(name="sslCipher", allow_empty=False, optional=True),
+            dict(name="username", allow_empty=False, optional=True),
+            dict(name="verifyServerCertificate", optional=True)
+        ], optional=True),
+    ], optional=True)
+]
+
+
+class CloudSqlBaseOperator(BaseOperator):
+    """
+    Abstract base operator for Google Cloud SQL operators to inherit from.
+    """
+    @apply_defaults
+    def __init__(self,
+                 project_id,
+                 name,
+                 gcp_conn_id='google_cloud_default',
+                 api_version='v1beta4',
+                 *args, **kwargs):
+        self.project_id = project_id
+        self.name = name
+        self.gcp_conn_id = gcp_conn_id
+        self.api_version = api_version
+        self._validate_inputs()
+        self._hook = CloudSqlHook(gcp_conn_id=self.gcp_conn_id,
+                                  api_version=self.api_version)
+        super(CloudSqlBaseOperator, self).__init__(*args, **kwargs)
+
+    def _validate_inputs(self):
+        if not self.project_id:
+            raise AirflowException("The required parameter 'project_id' is empty")
+        if not self.name:
+            raise AirflowException("The required parameter 'name' is empty")
+
+    def _check_if_instance_exists(self, name):
+        try:
+            return self._hook.get_instance(self.project_id, name)
+        except HttpError as e:
+            status = e.resp.status
+            if status == 404:
+                return False
+            raise e
+
+    def execute(self, context):
+        pass
+
+    @staticmethod
+    def _get_settings_version(instance):
+        return instance.get(SETTINGS).get(SETTINGS_VERSION)
+
+
+class CloudSqlInstanceInsertOperator(CloudSqlBaseOperator):
+    """
+    Creates a new Cloud SQL instance.
+    If an instance with the same name exists, no action will be taken and
+    the operator will succeed.
+
+    :param project_id: Google Cloud Platform project where the Cloud SQL
+        instance is to be created.
+    :type project_id: str
+    :param body: Body required by the Cloud SQL insert API, as described in
+        https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/instances/insert
+        #request-body
+    :type body: dict
+    :param name: Name of the Cloud SQL instance. This does not include the project ID.
+    :type name: str
+    :param gcp_conn_id: The connection ID used to connect to Google Cloud Platform.
+    :type gcp_conn_id: str
+    :param api_version: API version used (e.g. v1).
+    :type api_version: str
+    :param validate_body: True if body should be validated, False otherwise.
+    :type validate_body: bool
+    """
+    # [START gcp_sql_insert_template_fields]
+    template_fields = ('project_id', 'name', 'gcp_conn_id', 'api_version')
+    # [END gcp_sql_insert_template_fields]
+
+    @apply_defaults
+    def __init__(self,
+                 project_id,
+                 body,
+                 name,
+                 gcp_conn_id='google_cloud_default',
+                 api_version='v1beta4',
+                 validate_body=True,
+                 *args, **kwargs):
+        self.body = body
+        self.validate_body = validate_body
+        super(CloudSqlInstanceInsertOperator, self).__init__(
+            project_id=project_id, name=name, gcp_conn_id=gcp_conn_id,
+            api_version=api_version, *args, **kwargs)
+
+    def _validate_inputs(self):
+        super(CloudSqlInstanceInsertOperator, self)._validate_inputs()
+        if not self.body:
+            raise AirflowException("The required parameter 'body' is empty")
+
+    def _validate_body_fields(self):
+        if self.validate_body:
+            GcpBodyFieldValidator(CLOUD_SQL_VALIDATION,
+                                  api_version=self.api_version).validate(self.body)
+
+    def execute(self, context):
+        self._validate_body_fields()
+        if not self._check_if_instance_exists(self.name):
+            return self._hook.insert_instance(self.project_id, self.body)
+        else:
+            self.log.info("Cloud SQL with name {} already exists. Aborting insert."
+                          .format(self.name))
+            return True
+
+
+class CloudSqlInstancePatchOperator(CloudSqlBaseOperator):
+    """
+    Updates settings of a Cloud SQL instance.
+
+    Caution: This is a partial update, so only included values for the settings will be
+    updated.
+
+    In the request body, supply the relevant portions of an instance resource, according
+    to the rules of patch semantics.
+    https://cloud.google.com/sql/docs/mysql/admin-api/how-tos/performance#patch
+
+    :param project_id: Google Cloud Platform project where the Cloud SQL instance exists.
+    :type project_id: str
+    :param body: Body required by the Cloud SQL patch API, as described in
+        https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/instances/patch#request-body
+    :type body: dict
+    :param name: Name of the Cloud SQL instance. This does not include the project ID.
+    :type name: str
+    :param gcp_conn_id: The connection ID used to connect to Google Cloud Platform.
+    :type gcp_conn_id: str
+    :param api_version: API version used (e.g. v1).
+    :type api_version: str
+    """
+    # [START gcp_sql_patch_template_fields]
+    template_fields = ('project_id', 'name', 'gcp_conn_id', 'api_version')
+    # [END gcp_sql_patch_template_fields]
+
+    @apply_defaults
+    def __init__(self,
+                 project_id,
+                 body,
+                 name,
+                 gcp_conn_id='google_cloud_default',
+                 api_version='v1beta4',
+                 *args, **kwargs):
+        self.body = body
+        super(CloudSqlInstancePatchOperator, self).__init__(
+            project_id=project_id, name=name, gcp_conn_id=gcp_conn_id,
+            api_version=api_version, *args, **kwargs)
+
+    def _validate_inputs(self):
+        super(CloudSqlInstancePatchOperator, self)._validate_inputs()
+        if not self.body:
+            raise AirflowException("The required parameter 'body' is empty")
+
+    def execute(self, context):
+        if not self._check_if_instance_exists(self.name):
+            raise AirflowException('Cloud SQL instance {} does not exist. Please '
+                                   'specify another instance to patch.'
+                                   .format(self.name))
+        else:
+            return self._hook.patch_instance(self.project_id, self.body, self.name)
+
+
+class CloudSqlInstanceDeleteOperator(CloudSqlBaseOperator):
+    """
+    Deletes a Cloud SQL instance.
+
+    :param project_id: Google Cloud Platform project where the Cloud SQL instance exists.
+    :type project_id: str
+    :param name: Name of the Cloud SQL instance. This does not include the project ID.
+    :type name: str
+    :param gcp_conn_id: The connection ID used to connect to Google Cloud Platform.
+    :type gcp_conn_id: str
+    :param api_version: API version used (e.g. v1).
+    :type api_version: str
+    """
+    # [START gcp_sql_delete_template_fields]
+    template_fields = ('project_id', 'name', 'gcp_conn_id', 'api_version')
+    # [END gcp_sql_delete_template_fields]
+
+    @apply_defaults
+    def __init__(self,
+                 project_id,
+                 name,
+                 gcp_conn_id='google_cloud_default',
+                 api_version='v1beta4',
+                 *args, **kwargs):
+        super(CloudSqlInstanceDeleteOperator, self).__init__(
+            project_id=project_id, name=name, gcp_conn_id=gcp_conn_id,
+            api_version=api_version, *args, **kwargs)
+
+    def execute(self, context):
+        if not self._check_if_instance_exists(self.name):
+            print("Cloud SQL instance {} does not exist. Aborting delete."
+                  .format(self.name))
+            return True
+        else:
+            return self._hook.delete_instance(self.project_id, self.name)

--- a/docs/howto/operator.rst
+++ b/docs/howto/operator.rst
@@ -283,3 +283,155 @@ See `Adding the IAM service agent user role to the runtime service <https://clou
 If the source code for your function is in Google Source Repository, make sure that
 your service account has the Source Repository Viewer role so that the source code
 can be downloaded if necessary.
+
+CloudSqlInstanceDeleteOperator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Deletes a Cloud SQL instance in Google Cloud Platform.
+
+For parameter definition take a look at
+:class:`~airflow.contrib.operators.gcp_sql_operator.CloudSqlInstanceDeleteOperator`.
+
+Arguments
+"""""""""
+
+Some arguments in the example DAG are taken from Airflow variables:
+
+.. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_sql.py
+    :language: python
+    :start-after: [START howto_operator_cloudsql_arguments]
+    :end-before: [END howto_operator_cloudsql_arguments]
+
+Using the operator
+""""""""""""""""""
+
+.. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_sql.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_cloudsql_delete]
+    :end-before: [END howto_operator_cloudsql_delete]
+
+Templating
+""""""""""
+
+.. literalinclude:: ../../airflow/contrib/operators/gcp_sql_operator.py
+  :language: python
+  :dedent: 4
+  :start-after: [START gcp_sql_delete_template_fields]
+  :end-before: [END gcp_sql_delete_template_fields]
+
+More information
+""""""""""""""""
+
+See `Google Cloud SQL API documentation for delete
+<https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/instances/delete>`_.
+
+.. _CloudSqlInstanceInsertOperator:
+
+CloudSqlInstanceInsertOperator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Creates a new Cloud SQL instance in Google Cloud Platform.
+
+For parameter definition take a look at
+:class:`~airflow.contrib.operators.gcp_sql_operator.CloudSqlInstanceInsertOperator`.
+
+If an instance with the same name exists, no action will be taken and the operator
+will succeed.
+
+Arguments
+"""""""""
+
+Some arguments in the example DAG are taken from Airflow variables:
+
+.. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_sql.py
+    :language: python
+    :start-after: [START howto_operator_cloudsql_arguments]
+    :end-before: [END howto_operator_cloudsql_arguments]
+
+Example body defining the instance:
+
+.. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_sql.py
+    :language: python
+    :start-after: [START howto_operator_cloudsql_insert_body]
+    :end-before: [END howto_operator_cloudsql_insert_body]
+
+Using the operator
+""""""""""""""""""
+
+.. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_sql.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_cloudsql_insert]
+    :end-before: [END howto_operator_cloudsql_insert]
+
+Templating
+""""""""""
+
+.. literalinclude:: ../../airflow/contrib/operators/gcp_sql_operator.py
+  :language: python
+  :dedent: 4
+  :start-after: [START gcp_sql_insert_template_fields]
+  :end-before: [END gcp_sql_insert_template_fields]
+
+More information
+""""""""""""""""
+
+See `Google Cloud SQL API documentation for insert <https://cloud.google
+.com/sql/docs/mysql/admin-api/v1beta4/instances/insert>`_.
+
+
+.. _CloudSqlInstancePatchOperator:
+
+CloudSqlInstancePatchOperator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Updates settings of a Cloud SQL instance in Google Cloud Platform (partial update).
+
+For parameter definition take a look at
+:class:`~airflow.contrib.operators.gcp_sql_operator.CloudSqlInstancePatchOperator`.
+
+This is a partial update, so only values for the settings specified in the body
+will be set / updated. The rest of the existing instance's configuration will remain
+unchanged.
+
+Arguments
+"""""""""
+
+Some arguments in the example DAG are taken from Airflow variables:
+
+.. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_sql.py
+    :language: python
+    :start-after: [START howto_operator_cloudsql_arguments]
+    :end-before: [END howto_operator_cloudsql_arguments]
+
+Example body defining the instance:
+
+.. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_sql.py
+    :language: python
+    :start-after: [START howto_operator_cloudsql_patch_body]
+    :end-before: [END howto_operator_cloudsql_patch_body]
+
+Using the operator
+""""""""""""""""""
+
+.. literalinclude:: ../../airflow/contrib/example_dags/example_gcp_sql.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_cloudsql_patch]
+    :end-before: [END howto_operator_cloudsql_patch]
+
+Templating
+""""""""""
+
+.. literalinclude:: ../../airflow/contrib/operators/gcp_sql_operator.py
+  :language: python
+  :dedent: 4
+  :start-after: [START gcp_sql_patch_template_fields]
+  :end-before: [END gcp_sql_patch_template_fields]
+
+More information
+""""""""""""""""
+
+See `Google Cloud SQL API documentation for patch <https://cloud.google
+.com/sql/docs/mysql/admin-api/v1beta4/instances/patch>`_.

--- a/docs/integration.rst
+++ b/docs/integration.rst
@@ -501,6 +501,43 @@ BigQueryHook
 .. autoclass:: airflow.contrib.hooks.bigquery_hook.BigQueryHook
     :members:
 
+Cloud SQL
+'''''''''
+
+Cloud SQL Operators
+"""""""""""""""""""
+
+- :ref:`CloudSqlInstanceDeleteOperator` : delete a Cloud SQL instance.
+- :ref:`CloudSqlInstanceInsertOperator` : create a new Cloud SQL instance.
+- :ref:`CloudSqlInstancePatchOperator` : patch a Cloud SQL instance.
+
+.. CloudSqlInstanceDeleteOperator:
+
+CloudSqlInstanceDeleteOperator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: airflow.contrib.operators.gcp_sql_operator.CloudSqlInstanceDeleteOperator
+
+.. CloudSqlInstanceInsertOperator:
+
+CloudSqlInstanceInsertOperator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: airflow.contrib.operators.gcp_sql_operator.CloudSqlInstanceInsertOperator
+
+.. CloudSqlInstancePatchOperator:
+
+CloudSqlInstancePatchOperator
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: airflow.contrib.operators.gcp_sql_operator.CloudSqlInstancePatchOperator
+
+Cloud SQL Hook
+""""""""""""""""""""
+
+.. autoclass:: airflow.contrib.hooks.gcp_sql_hook.CloudSqlHook
+    :members:
+
 Compute Engine
 ''''''''''''''
 

--- a/tests/contrib/operators/test_gcp_function_operator.py
+++ b/tests/contrib/operators/test_gcp_function_operator.py
@@ -344,7 +344,7 @@ class GcfFunctionDeployTest(unittest.TestCase):
          "Parameter 'sourceUploadUrl' is empty in the body and argument "
          "'zip_path' is missing or empty."),
         ({'sourceArchiveUrl': 'gs://adasda', 'sourceRepository': ''},
-         "The field 'source_code.sourceRepository' should be dictionary type"),
+         "The field 'source_code.sourceRepository' should be of dictionary type"),
         ({'sourceUploadUrl': '', 'sourceRepository': ''},
          "Parameter 'sourceUploadUrl' is empty in the body and argument 'zip_path' "
          "is missing or empty."),
@@ -360,7 +360,7 @@ class GcfFunctionDeployTest(unittest.TestCase):
         ({'sourceUploadUrl': ''}, "Parameter 'sourceUploadUrl' is empty in the body "
                                   "and argument 'zip_path' is missing or empty."),
         ({'sourceRepository': ''}, "The field 'source_code.sourceRepository' "
-                                   "should be dictionary type"),
+                                   "should be of dictionary type"),
         ({'sourceRepository': {}}, "The required body field "
                                    "'source_code.sourceRepository.url' is missing"),
         ({'sourceRepository': {'url': ''}},
@@ -452,7 +452,7 @@ class GcfFunctionDeployTest(unittest.TestCase):
                            'service': 'service_name',
                            'failurePolicy': {'retry': ''}}},
          "The field 'trigger.eventTrigger.failurePolicy.retry' "
-         "should be dictionary type")
+         "should be of dictionary type")
     ]
     )
     @mock.patch('airflow.contrib.operators.gcp_function_operator.GcfHook')

--- a/tests/contrib/operators/test_gcp_sql_operator.py
+++ b/tests/contrib/operators/test_gcp_sql_operator.py
@@ -33,9 +33,9 @@ except ImportError:
         mock = None
 
 PROJECT_ID = "project-id"
-NAME = "test-name"
+INSTANCE_NAME = "test-name"
 INSERT_BODY = {
-    "name": NAME,
+    "name": INSTANCE_NAME,
     "settings": {
         "tier": "db-n1-standard-1",
         "backupConfiguration": {
@@ -102,7 +102,7 @@ INSERT_BODY = {
     }
 }
 PATCH_BODY = {
-    "name": NAME,
+    "name": INSTANCE_NAME,
     "settings": {
         "tier": "db-n1-standard-2",
         "dataDiskType": "PD_HDD"
@@ -120,7 +120,7 @@ class CloudSqlTest(unittest.TestCase):
         mock_hook.return_value.insert_instance.return_value = True
         op = CloudSqlInstanceInsertOperator(
             project_id=PROJECT_ID,
-            name=NAME,
+            instance=INSTANCE_NAME,
             body=INSERT_BODY,
             task_id="id"
         )
@@ -140,7 +140,7 @@ class CloudSqlTest(unittest.TestCase):
         mock_hook.return_value.insert_instance.return_value = True
         op = CloudSqlInstanceInsertOperator(
             project_id=PROJECT_ID,
-            name=NAME,
+            instance=INSTANCE_NAME,
             body=INSERT_BODY,
             task_id="id"
         )
@@ -156,7 +156,7 @@ class CloudSqlTest(unittest.TestCase):
             op = CloudSqlInstanceInsertOperator(
                 project_id="",
                 body=INSERT_BODY,
-                name=NAME,
+                instance=INSTANCE_NAME,
                 task_id="id"
             )
             op.execute(None)
@@ -170,7 +170,7 @@ class CloudSqlTest(unittest.TestCase):
             op = CloudSqlInstanceInsertOperator(
                 project_id=PROJECT_ID,
                 body={},
-                name=NAME,
+                instance=INSTANCE_NAME,
                 task_id="id"
             )
             op.execute(None)
@@ -179,23 +179,23 @@ class CloudSqlTest(unittest.TestCase):
         mock_hook.assert_not_called()
 
     @mock.patch("airflow.contrib.operators.gcp_sql_operator.CloudSqlHook")
-    def test_insert_should_throw_ex_when_empty_name(self, mock_hook):
+    def test_insert_should_throw_ex_when_empty_instance(self, mock_hook):
         with self.assertRaises(AirflowException) as cm:
             op = CloudSqlInstanceInsertOperator(
                 project_id=PROJECT_ID,
                 body=INSERT_BODY,
-                name="",
+                instance="",
                 task_id="id"
             )
             op.execute(None)
         err = cm.exception
-        self.assertIn("The required parameter 'name' is empty", str(err))
+        self.assertIn("The required parameter 'instance' is empty", str(err))
         mock_hook.assert_not_called()
 
     @mock.patch("airflow.contrib.operators.gcp_sql_operator.CloudSqlHook")
     def test_insert_should_validate_list_type(self, mock_hook):
         wrong_list_type_body = {
-            "name": NAME,
+            "name": INSTANCE_NAME,
             "settings": {
                 "tier": "db-n1-standard-1",
                 "ipConfiguration": {
@@ -208,7 +208,7 @@ class CloudSqlTest(unittest.TestCase):
             op = CloudSqlInstanceInsertOperator(
                 project_id=PROJECT_ID,
                 body=wrong_list_type_body,
-                name=NAME,
+                instance=INSTANCE_NAME,
                 task_id="id"
             )
             op.execute(None)
@@ -221,7 +221,7 @@ class CloudSqlTest(unittest.TestCase):
     @mock.patch("airflow.contrib.operators.gcp_sql_operator.CloudSqlHook")
     def test_insert_should_validate_non_empty_fields(self, mock_hook):
         empty_tier_body = {
-            "name": NAME,
+            "name": INSTANCE_NAME,
             "settings": {
                 "tier": "",  # Field can't be empty (defined in CLOUD_SQL_VALIDATION).
                              # Testing if the validation catches this.
@@ -231,7 +231,7 @@ class CloudSqlTest(unittest.TestCase):
             op = CloudSqlInstanceInsertOperator(
                 project_id=PROJECT_ID,
                 body=empty_tier_body,
-                name=NAME,
+                instance=INSTANCE_NAME,
                 task_id="id"
             )
             op.execute(None)
@@ -247,14 +247,14 @@ class CloudSqlTest(unittest.TestCase):
         op = CloudSqlInstancePatchOperator(
             project_id=PROJECT_ID,
             body=PATCH_BODY,
-            name=NAME,
+            instance=INSTANCE_NAME,
             task_id="id"
         )
         result = op.execute(None)
         mock_hook.assert_called_once_with(api_version="v1beta4",
                                           gcp_conn_id="google_cloud_default")
         mock_hook.return_value.patch_instance.assert_called_once_with(
-            PROJECT_ID, PATCH_BODY, NAME
+            PROJECT_ID, PATCH_BODY, INSTANCE_NAME
         )
         self.assertTrue(result)
 
@@ -268,7 +268,7 @@ class CloudSqlTest(unittest.TestCase):
             op = CloudSqlInstancePatchOperator(
                 project_id=PROJECT_ID,
                 body=PATCH_BODY,
-                name=NAME,
+                instance=INSTANCE_NAME,
                 task_id="id"
             )
             op.execute(None)
@@ -285,7 +285,7 @@ class CloudSqlTest(unittest.TestCase):
         _check_if_instance_exists.return_value = True
         op = CloudSqlInstanceDeleteOperator(
             project_id=PROJECT_ID,
-            name=NAME,
+            instance=INSTANCE_NAME,
             task_id="id"
         )
         result = op.execute(None)
@@ -293,7 +293,7 @@ class CloudSqlTest(unittest.TestCase):
         mock_hook.assert_called_once_with(api_version="v1beta4",
                                           gcp_conn_id="google_cloud_default")
         mock_hook.return_value.delete_instance.assert_called_once_with(
-            PROJECT_ID, NAME
+            PROJECT_ID, INSTANCE_NAME
         )
 
     @mock.patch("airflow.contrib.operators.gcp_sql_operator"
@@ -304,7 +304,7 @@ class CloudSqlTest(unittest.TestCase):
         _check_if_instance_exists.return_value = False
         op = CloudSqlInstanceDeleteOperator(
             project_id=PROJECT_ID,
-            name=NAME,
+            instance=INSTANCE_NAME,
             task_id="id"
         )
         result = op.execute(None)

--- a/tests/contrib/operators/test_gcp_sql_operator.py
+++ b/tests/contrib/operators/test_gcp_sql_operator.py
@@ -1,0 +1,314 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from airflow import AirflowException
+from airflow.contrib.operators.gcp_sql_operator import CloudSqlInstanceInsertOperator, \
+    CloudSqlInstancePatchOperator, CloudSqlInstanceDeleteOperator
+
+try:
+    # noinspection PyProtectedMember
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+PROJECT_ID = "project-id"
+NAME = "test-name"
+INSERT_BODY = {
+    "name": NAME,
+    "settings": {
+        "tier": "db-n1-standard-1",
+        "backupConfiguration": {
+            "binaryLogEnabled": True,
+            "enabled": True,
+            "replicationLogArchivingEnabled": True,
+            "startTime": "05:00"
+        },
+        "activationPolicy": "ALWAYS",
+        "authorizedGaeApplications": [],
+        "crashSafeReplicationEnabled": True,
+        "dataDiskSizeGb": 30,
+        "dataDiskType": "PD_SSD",
+        "databaseFlags": [],
+        "ipConfiguration": {
+            "ipv4Enabled": True,
+            "authorizedNetworks": [
+                {
+                    "value": "192.168.100.0/24",
+                    "name": "network1",
+                    "expirationTime": "2012-11-15T16:19:00.094Z"
+                },
+            ],
+            "privateNetwork": "/vpc/resource/link",
+            "requireSsl": True
+        },
+        "locationPreference": {
+            "zone": "europe-west4-a",
+            "followGaeApplication": "/app/engine/application/to/follow"
+        },
+        "maintenanceWindow": {
+            "hour": 5,
+            "day": 7,
+            "updateTrack": "canary"
+        },
+        "pricingPlan": "PER_USE",
+        "replicationType": "ASYNCHRONOUS",
+        "storageAutoResize": False,
+        "storageAutoResizeLimit": 0,
+        "userLabels": {
+            "my-key": "my-value"
+        }
+    },
+    "databaseVersion": "MYSQL_5_7",
+    "failoverReplica": {
+        "name": "replica-1"
+    },
+    "masterInstanceName": "master-instance-1",
+    "onPremisesConfiguration": {},
+    "region": "europe-west4",
+    "replicaConfiguration": {
+        "mysqlReplicaConfiguration": {
+            "caCertificate": "cert-pem",
+            "clientCertificate": "cert-pem",
+            "clientKey": "cert-pem",
+            "connectRetryInterval": 30,
+            "dumpFilePath": "/path/to/dump",
+            "masterHeartbeatPeriod": 100,
+            "password": "secret_pass",
+            "sslCipher": "list-of-ciphers",
+            "username": "user",
+            "verifyServerCertificate": True
+        },
+    }
+}
+PATCH_BODY = {
+    "name": NAME,
+    "settings": {
+        "tier": "db-n1-standard-2",
+        "dataDiskType": "PD_HDD"
+    },
+    "region": "europe-west4"
+}
+
+
+class CloudSqlTest(unittest.TestCase):
+    @mock.patch("airflow.contrib.operators.gcp_sql_operator"
+                ".CloudSqlInstanceInsertOperator._check_if_instance_exists")
+    @mock.patch("airflow.contrib.operators.gcp_sql_operator.CloudSqlHook")
+    def test_instance_insert(self, mock_hook, _check_if_instance_exists):
+        _check_if_instance_exists.return_value = False
+        mock_hook.return_value.insert_instance.return_value = True
+        op = CloudSqlInstanceInsertOperator(
+            project_id=PROJECT_ID,
+            name=NAME,
+            body=INSERT_BODY,
+            task_id="id"
+        )
+        result = op.execute(None)
+        mock_hook.assert_called_once_with(api_version="v1beta4",
+                                          gcp_conn_id="google_cloud_default")
+        mock_hook.return_value.insert_instance.assert_called_once_with(
+            PROJECT_ID, INSERT_BODY
+        )
+        self.assertTrue(result)
+
+    @mock.patch("airflow.contrib.operators.gcp_sql_operator"
+                ".CloudSqlInstanceInsertOperator._check_if_instance_exists")
+    @mock.patch("airflow.contrib.operators.gcp_sql_operator.CloudSqlHook")
+    def test_instance_insert_idempotent(self, mock_hook, _check_if_instance_exists):
+        _check_if_instance_exists.return_value = True
+        mock_hook.return_value.insert_instance.return_value = True
+        op = CloudSqlInstanceInsertOperator(
+            project_id=PROJECT_ID,
+            name=NAME,
+            body=INSERT_BODY,
+            task_id="id"
+        )
+        result = op.execute(None)
+        mock_hook.assert_called_once_with(api_version="v1beta4",
+                                          gcp_conn_id="google_cloud_default")
+        mock_hook.return_value.insert_instance.assert_not_called()
+        self.assertTrue(result)
+
+    @mock.patch("airflow.contrib.operators.gcp_sql_operator.CloudSqlHook")
+    def test_insert_should_throw_ex_when_empty_project_id(self, mock_hook):
+        with self.assertRaises(AirflowException) as cm:
+            op = CloudSqlInstanceInsertOperator(
+                project_id="",
+                body=INSERT_BODY,
+                name=NAME,
+                task_id="id"
+            )
+            op.execute(None)
+        err = cm.exception
+        self.assertIn("The required parameter 'project_id' is empty", str(err))
+        mock_hook.assert_not_called()
+
+    @mock.patch("airflow.contrib.operators.gcp_sql_operator.CloudSqlHook")
+    def test_insert_should_throw_ex_when_empty_body(self, mock_hook):
+        with self.assertRaises(AirflowException) as cm:
+            op = CloudSqlInstanceInsertOperator(
+                project_id=PROJECT_ID,
+                body={},
+                name=NAME,
+                task_id="id"
+            )
+            op.execute(None)
+        err = cm.exception
+        self.assertIn("The required parameter 'body' is empty", str(err))
+        mock_hook.assert_not_called()
+
+    @mock.patch("airflow.contrib.operators.gcp_sql_operator.CloudSqlHook")
+    def test_insert_should_throw_ex_when_empty_name(self, mock_hook):
+        with self.assertRaises(AirflowException) as cm:
+            op = CloudSqlInstanceInsertOperator(
+                project_id=PROJECT_ID,
+                body=INSERT_BODY,
+                name="",
+                task_id="id"
+            )
+            op.execute(None)
+        err = cm.exception
+        self.assertIn("The required parameter 'name' is empty", str(err))
+        mock_hook.assert_not_called()
+
+    @mock.patch("airflow.contrib.operators.gcp_sql_operator.CloudSqlHook")
+    def test_insert_should_validate_list_type(self, mock_hook):
+        wrong_list_type_body = {
+            "name": NAME,
+            "settings": {
+                "tier": "db-n1-standard-1",
+                "ipConfiguration": {
+                    "authorizedNetworks": {}  # Should be a list, not a dict.
+                                              # Testing if the validation catches this.
+                }
+            }
+        }
+        with self.assertRaises(AirflowException) as cm:
+            op = CloudSqlInstanceInsertOperator(
+                project_id=PROJECT_ID,
+                body=wrong_list_type_body,
+                name=NAME,
+                task_id="id"
+            )
+            op.execute(None)
+        err = cm.exception
+        self.assertIn("The field 'settings.ipConfiguration.authorizedNetworks' "
+                      "should be of list type according to the specification", str(err))
+        mock_hook.assert_called_once_with(api_version="v1beta4",
+                                          gcp_conn_id="google_cloud_default")
+
+    @mock.patch("airflow.contrib.operators.gcp_sql_operator.CloudSqlHook")
+    def test_insert_should_validate_non_empty_fields(self, mock_hook):
+        empty_tier_body = {
+            "name": NAME,
+            "settings": {
+                "tier": "",  # Field can't be empty (defined in CLOUD_SQL_VALIDATION).
+                             # Testing if the validation catches this.
+            }
+        }
+        with self.assertRaises(AirflowException) as cm:
+            op = CloudSqlInstanceInsertOperator(
+                project_id=PROJECT_ID,
+                body=empty_tier_body,
+                name=NAME,
+                task_id="id"
+            )
+            op.execute(None)
+        err = cm.exception
+        self.assertIn("The body field 'settings.tier' can't be empty. "
+                      "Please provide a value.", str(err))
+        mock_hook.assert_called_once_with(api_version="v1beta4",
+                                          gcp_conn_id="google_cloud_default")
+
+    @mock.patch("airflow.contrib.operators.gcp_sql_operator.CloudSqlHook")
+    def test_instance_patch(self, mock_hook):
+        mock_hook.return_value.patch_instance.return_value = True
+        op = CloudSqlInstancePatchOperator(
+            project_id=PROJECT_ID,
+            body=PATCH_BODY,
+            name=NAME,
+            task_id="id"
+        )
+        result = op.execute(None)
+        mock_hook.assert_called_once_with(api_version="v1beta4",
+                                          gcp_conn_id="google_cloud_default")
+        mock_hook.return_value.patch_instance.assert_called_once_with(
+            PROJECT_ID, PATCH_BODY, NAME
+        )
+        self.assertTrue(result)
+
+    @mock.patch("airflow.contrib.operators.gcp_sql_operator"
+                ".CloudSqlInstancePatchOperator._check_if_instance_exists")
+    @mock.patch("airflow.contrib.operators.gcp_sql_operator.CloudSqlHook")
+    def test_instance_patch_should_bubble_up_ex_if_not_exists(self, mock_hook,
+                                                              _check_if_instance_exists):
+        _check_if_instance_exists.return_value = False
+        with self.assertRaises(AirflowException) as cm:
+            op = CloudSqlInstancePatchOperator(
+                project_id=PROJECT_ID,
+                body=PATCH_BODY,
+                name=NAME,
+                task_id="id"
+            )
+            op.execute(None)
+        err = cm.exception
+        self.assertIn('specify another instance to patch', str(err))
+        mock_hook.assert_called_once_with(api_version="v1beta4",
+                                          gcp_conn_id="google_cloud_default")
+        mock_hook.return_value.patch_instance.assert_not_called()
+
+    @mock.patch("airflow.contrib.operators.gcp_sql_operator"
+                ".CloudSqlInstanceDeleteOperator._check_if_instance_exists")
+    @mock.patch("airflow.contrib.operators.gcp_sql_operator.CloudSqlHook")
+    def test_instance_delete(self, mock_hook, _check_if_instance_exists):
+        _check_if_instance_exists.return_value = True
+        op = CloudSqlInstanceDeleteOperator(
+            project_id=PROJECT_ID,
+            name=NAME,
+            task_id="id"
+        )
+        result = op.execute(None)
+        self.assertTrue(result)
+        mock_hook.assert_called_once_with(api_version="v1beta4",
+                                          gcp_conn_id="google_cloud_default")
+        mock_hook.return_value.delete_instance.assert_called_once_with(
+            PROJECT_ID, NAME
+        )
+
+    @mock.patch("airflow.contrib.operators.gcp_sql_operator"
+                ".CloudSqlInstanceDeleteOperator._check_if_instance_exists")
+    @mock.patch("airflow.contrib.operators.gcp_sql_operator.CloudSqlHook")
+    def test_instance_delete_should_abort_and_succeed_if_not_exists(
+            self, mock_hook, _check_if_instance_exists):
+        _check_if_instance_exists.return_value = False
+        op = CloudSqlInstanceDeleteOperator(
+            project_id=PROJECT_ID,
+            name=NAME,
+            task_id="id"
+        )
+        result = op.execute(None)
+        self.assertTrue(result)
+        mock_hook.assert_called_once_with(api_version="v1beta4",
+                                          gcp_conn_id="google_cloud_default")
+        mock_hook.return_value.delete_instance.assert_not_called()


### PR DESCRIPTION
Add CloudSqlInstanceDeployOperator, CloudSqlInstancePatchOperator and CloudSqlInstanceDeleteOperator.

Each operator includes:
- core logic
- input params validation
- unit tests
- presence in the example DAG
- docstrings
- How-to and Integration documentation

Additionally, small improvements to GcpBodyFieldValidator were made:
- add simple list validation capability (type="list")
- introduced parameter allow_empty, which can be set to False
	to test for non-emptiness of a string instead of specifying
	a regexp.